### PR TITLE
Fixing test to get running on Arch

### DIFF
--- a/test/worker_test.rb
+++ b/test/worker_test.rb
@@ -76,6 +76,9 @@ class WorkerTest < LocaljobTestCase
 
       pid = fork { @worker.work }
 
+      # Hack to account for race condition, 0.01s should be plenty
+      sleep 0.01
+
       Process.kill("QUIT", pid)
       Process.wait
 


### PR DESCRIPTION
For some reason Process.kill wasn't working when I tried it.  Without digging in deep the solution I have seems to work.  I haven't tested on Mac, but tested on my Arch box.
