### PR TITLE
Handle destroyed or non-existent queue better

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,10 @@
+# http://EditorConfig.org
+
+root = true
+
+[*]
+charset = utf-8
+indent_style = space
+indent_size = 2
+insert_final_newline = true
+

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 .bundle
 .config
 .yardoc
+.idea
 Gemfile.lock
 InstalledFiles
 _yardoc

--- a/lib/localjob.rb
+++ b/lib/localjob.rb
@@ -10,7 +10,7 @@ class Localjob
   extend Forwardable
 
   attr_reader :name
-  attr_accessor :queue
+  attr_writer :queue
 
   def_delegators :queue, :stats, :destroy, :size
 

--- a/lib/localjob/sysv_adapter.rb
+++ b/lib/localjob/sysv_adapter.rb
@@ -29,6 +29,8 @@ class Localjob
 
     def destroy
       queue.destroy
+    rescue Errno::EINVAL
+      # Queue likely doesn't exist or was destroyed.
     end
   end
 end

--- a/lib/localjob/worker.rb
+++ b/lib/localjob/worker.rb
@@ -10,6 +10,7 @@ class Localjob
       @queue = Localjob.new(@queue) if queue.kind_of?(Fixnum)
       @options = options
       @shutdown = false
+      @thread = nil
     end
 
     def process(job)

--- a/lib/localjob/worker.rb
+++ b/lib/localjob/worker.rb
@@ -1,3 +1,5 @@
+require 'fileutils'
+
 class Localjob
   class Worker
     TERMINATION_MESSAGE = "__TERMINATE__"
@@ -60,7 +62,7 @@ class Localjob
 
     def shutdown!
       logger.info "Worker #{pid} shutting down.."
-      File.rm(@options[:pid_file]) if @options[:pid_file]
+      FileUtils.rm(@options[:pid_file]) if @options[:pid_file]
       return false if @thread
       exit!
     end

--- a/localjob.gemspec
+++ b/localjob.gemspec
@@ -24,4 +24,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "mocha"
+  spec.add_development_dependency "minitest", "~> 5.8.4"
 end

--- a/test/localjob_test.rb
+++ b/test/localjob_test.rb
@@ -27,4 +27,18 @@ class LocaljobTest < LocaljobTestCase
     assert_equal 1, @localjob.size
     assert_equal 1, other.size
   end
+
+	def test_send_raises_error_if_queue_does_not_exist
+		assert_raises Errno::EINVAL do
+			@localjob.destroy
+			@localjob << WalrusJob.new("move")
+		end
+	end
+
+  def test_shift_raises_error_if_queue_does_not_exist
+	  assert_raises Errno::EINVAL do
+		  @localjob.destroy
+		  @localjob.shift
+	  end
+  end
 end

--- a/test/sysv_adapter_test.rb
+++ b/test/sysv_adapter_test.rb
@@ -26,4 +26,9 @@ class SysvAdapterTest < LocaljobTestCase
     assert_equal 20, @localjob.stats[:size]
     assert_equal 1,  @localjob.stats[:count]
   end
+
+  def test_multiple_destroys_do_not_raise_exception
+    @localjob.destroy
+    @localjob.destroy
+  end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,14 +1,13 @@
 require 'coveralls'
 Coveralls.wear!
 
-require 'minitest/unit'
 require 'minitest/autorun'
 $:<< File.dirname(__FILE__) + "/../lib"
 require 'localjob'
 require "mocha/setup"
 require 'jobs'
 
-class LocaljobTestCase < MiniTest::Unit::TestCase
+class LocaljobTestCase < MiniTest::Test
   protected
   # This is a method to make sure the logger is set right.
   def worker(queue)
@@ -29,10 +28,7 @@ class LocaljobTestCase < MiniTest::Unit::TestCase
   end
 
   def logger
-    return @logger if @logger
-
-    output_file = ENV["DEBUG"] ? STDOUT : "/dev/null"
-    @logger = Logger.new(output_file)
+    @logger ||= Logger.new(ENV["DEBUG"] ? STDOUT : "/dev/null")
   end
 
   def clear_queues

--- a/test/worker_test.rb
+++ b/test/worker_test.rb
@@ -110,4 +110,14 @@ class WorkerTest < LocaljobTestCase
     @worker.expects(:exit!)
     @worker.work
   end
+
+  def test_worker_stops_when_it_can_not_communicate_with_queue
+    localjob = Localjob.new(0xABCDEF12)
+    worker = Localjob::Worker.new(localjob, logger: Logger.new('/dev/null'))
+
+    localjob.destroy
+
+    worker.expects(:shutdown!)
+    worker.work
+  end
 end


### PR DESCRIPTION
There didn't seem to be much in the way of detecting that a queue wasn't available. It appeared to return a `Errno::EINVAL` in every case. This was evident when a worker was started and then another process destroyed the same queue that the worker was using. My assumption was that the worker should quit if the queue isn't available.

