### PR TITLE
Option to Localjob::Worker to send the existing logger to performing job

### DIFF
--- a/lib/localjob/worker.rb
+++ b/lib/localjob/worker.rb
@@ -7,6 +7,10 @@ class Localjob
     attr_accessor :logger
     attr_reader :options, :queue
 
+    # Params:
+    # +option+::
+    #   +pid_file+:: File path for storing PID value
+    #   +job_needs_logger+:: Boolean that indicates that the logger instance should be passed to the job's perform method. Default is false.
     def initialize(queue, logger: Logger.new(STDOUT), **options)
       @logger = logger
       @queue = queue.kind_of?(Fixnum) ? Localjob.new(@queue) : queue
@@ -17,7 +21,11 @@ class Localjob
 
     def process(job)
       logger.info "Worker #{pid}: #{job.inspect}"
-      job.perform
+      if @options[:job_needs_logger]
+        job.perform(logger)
+      else
+        job.perform
+      end
     end
 
     def pid

--- a/test/jobs.rb
+++ b/test/jobs.rb
@@ -9,3 +9,9 @@ class AngryWalrusJob < Struct.new(:angryness)
     raise "I am this angry: #{angryness}"
   end
 end
+
+class WaterLoggedWalrusJob < Struct.new(:level)
+  def perform(logger)
+    logger.warn("I'm #{level} water logged")
+  end
+end

--- a/test/worker_test.rb
+++ b/test/worker_test.rb
@@ -120,4 +120,22 @@ class WorkerTest < LocaljobTestCase
     worker.expects(:shutdown!)
     worker.work
   end
+
+  def test_options_parameter
+    worker = Localjob::Worker.new(@localjob, logger: Logger.new('/dev/null'))
+    assert_empty worker.options
+    assert_nil worker.options[:pid_file]
+    assert_nil worker.options[:job_needs_logger]
+
+    worker = Localjob::Worker.new(@localjob, logger: Logger.new('/dev/null'), pid_file: '/dev/null', job_needs_logger: true)
+    assert_equal '/dev/null', worker.options[:pid_file]
+    assert_same true, worker.options[:job_needs_logger]
+  end
+
+  def test_process_sends_logger_to_job_perform
+    l = Logger.new('/dev/null')
+    l.expects(:warn).once
+    worker = Localjob::Worker.new(@localjob, logger: l, job_needs_logger: true)
+    worker.process(WaterLoggedWalrusJob.new('highly'))
+  end
 end


### PR DESCRIPTION
This provides the option to `Localjob::Worker` so that it's `Logger` instance can be shared with the performing jobs. 

The justification for this is that if you desire all the output from the worker's processed jobs to be sent to the same log, you'd need to create separate instances of the `Logger` class. 
